### PR TITLE
NK-18 모든 구글 뉴스 http -> https로 수정

### DIFF
--- a/core/src/main/res/raw/news_data_ar.txt
+++ b/core/src/main/res/raw/news_data_ar.txt
@@ -15,43 +15,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -62,48 +62,48 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "أخبار محلية",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=awkl&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=awkl&output=rss"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_eg&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -311,43 +311,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -400,43 +400,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -447,48 +447,48 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "أخبار محلية",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=awkl&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=awkl&output=rss"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_sa&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -621,43 +621,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -716,43 +716,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -781,43 +781,43 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_me&hl=ar&topic=m&output=rss"
                         }
                     ]
                 },
@@ -828,48 +828,48 @@
                         {
                             "topic_name": "أهم الأخبار",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "أخبار محلية",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=n&output=rss"
                         },
                         {
                             "topic_name": "العالم العربي",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=awkl&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=awkl&output=rss"
                         },
                         {
                             "topic_name": "العالم",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=w&output=rss"
                         },
                         {
                             "topic_name": "أعمال",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=b&output=rss"
                         },
                         {
                             "topic_name": "علوم/تكنولوجيا",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=t&output=rss"
                         },
                         {
                             "topic_name": "ترفيه",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=e&output=rss"
                         },
                         {
                             "topic_name": "رياضة",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=s&output=rss"
                         },
                         {
                             "topic_name": "صحة",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ar_lb&hl=ar&topic=m&output=rss"
                         }
                     ]
                 }

--- a/core/src/main/res/raw/news_data_cs.txt
+++ b/core/src/main/res/raw/news_data_cs.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Hlavní události",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Svět",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Domov",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Podnikání",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Věda/technika",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Kultura a šoubyznys",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Život",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=l&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=l&output=rss"
                         },
                         {
                             "topic_name": "Další hlavní události",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cs_cz&hl=cs&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_de.txt
+++ b/core/src/main/res/raw/news_data_de.txt
@@ -15,43 +15,43 @@
                         {
                             "topic_name": "Schlagzeilen",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "International",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Deutschland",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Wirtschaft",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Wissen/Technik",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Unterhaltung",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Gesundheit",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=de&hl=de&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de&hl=de&topic=m&output=rss"
                         }
                     ]
                 },
@@ -371,48 +371,48 @@
                         {
                             "topic_name": "Schlagzeilen",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "International",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Österreich",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Wirtschaft",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Wissen/Technik",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Unterhaltung",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Gesundheit",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Weitere Schlagzeilen",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=de_at&hl=de&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=de_at&hl=de&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_el.txt
+++ b/core/src/main/res/raw/news_data_el.txt
@@ -15,43 +15,43 @@
                         {
                             "topic_name": "Κυριότερες ειδήσεις",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Κόσμος",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Ελλάδα",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Επιχειρήσεις",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ψυχαγωγία",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Αθλητικά",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Επιστήμη και τεχνολογία",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Πολιτική",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=p&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=el_gr&hl=el&topic=p&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_en.txt
+++ b/core/src/main/res/raw/news_data_en.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=w"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=w"
                         },
                         {
                             "topic_name": "U.S.",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=n"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=n"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=b"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=b"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=tc"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=tc"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=e"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=e"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=s"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=s"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=snc"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=snc"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=m"
+                            "url": "https://news.google.com/news?cf=all&ned=us&hl=en&output=rss&topic=m"
                         }
                     ]
                 },
@@ -568,53 +568,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Canada",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "More Top Stories",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=ca&hl=en&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ca&hl=en&topic=h&output=rss"
                         }
                     ]
                 },
@@ -824,53 +824,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "U.K.",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Spotlight",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=uk&hl=en&topic=ir&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk&hl=en&topic=ir&output=rss"
                         }
                     ]
                 },
@@ -1214,53 +1214,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Ireland",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "More Top Stories",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ie&hl=en&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1396,53 +1396,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Australia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "More Top Stories",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=au&hl=en&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=au&hl=en&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1734,53 +1734,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "New Zealand",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "More Top Stories",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=nz&hl=en&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nz&hl=en&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2171,53 +2171,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Singapore",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Southeast Asia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=se&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=se&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_sg&hl=en&topic=m&output=rss"
                         }
                     ]
                 },
@@ -2333,58 +2333,58 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "India",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "More Top Stories",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=h&output=rss"
                         },
                         {
                             "topic_name": "Spotlight",
                             "topic_id": "11",
-                            "url": "http://news.google.com/news?cf=all&ned=in&hl=en&topic=ir&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=in&hl=en&topic=ir&output=rss"
                         }
                     ]
                 },
@@ -2525,53 +2525,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Philippines",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Southeast Asia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=se&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=se&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ph&hl=en&topic=m&output=rss"
                         }
                     ]
                 },
@@ -2677,53 +2677,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Malaysia",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Southeast Asia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=se&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=se&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_my&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_my&hl=en&topic=m&output=rss"
                         }
                     ]
                 },
@@ -2894,48 +2894,48 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Pakistan",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_pk&hl=en&topic=snc&output=rss"
                         }
                     ]
                 },
@@ -3024,53 +3024,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Africa",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=af&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=af&output=rss"
                         },
                         {
                             "topic_name": "South Africa",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_za&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_za&hl=en&topic=m&output=rss"
                         }
                     ]
                 },
@@ -3134,53 +3134,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Nigeria",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Africa",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=af&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=af&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ng&hl=en&topic=m&output=rss"
                         }
                     ]
                 }
@@ -3197,48 +3197,48 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Ethiopia",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Africa",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=af&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=af&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Sci/Tech",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_et&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_et&hl=en&topic=m&output=rss"
                         }
                     ]
                 }
@@ -3255,53 +3255,53 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Tanzania",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Africa",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=af&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=af&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Technology",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=tc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=tc&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Science",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=snc&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=snc&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_tz&hl=en&topic=m&output=rss"
                         }
                     ]
                 }
@@ -3318,48 +3318,48 @@
                         {
                             "topic_name": "Top Stories",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Kenya",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Africa",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=af&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=af&output=rss"
                         },
                         {
                             "topic_name": "World",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Business",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Sci/Tech",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sports",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Health",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=en_ke&hl=en&topic=m&output=rss"
                         }
                     ]
                 }

--- a/core/src/main/res/raw/news_data_es.txt
+++ b/core/src/main/res/raw/news_data_es.txt
@@ -325,48 +325,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 }
@@ -383,48 +383,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "México",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_mx&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -435,48 +435,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -846,48 +846,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Colombia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_co&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_co&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -898,48 +898,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1132,48 +1132,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Argentina",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ar&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1184,48 +1184,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1351,48 +1351,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Perú",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_pe&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1403,48 +1403,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1727,48 +1727,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Venezuela",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_ve&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1779,48 +1779,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -1968,48 +1968,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Chile",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cl&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2020,48 +2020,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2157,48 +2157,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2299,48 +2299,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2543,48 +2543,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2613,48 +2613,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2750,48 +2750,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2862,48 +2862,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Cuba",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_cu&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -2914,48 +2914,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3026,48 +3026,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3160,48 +3160,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3270,48 +3270,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3340,48 +3340,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3477,48 +3477,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3660,48 +3660,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 },
@@ -3802,48 +3802,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         },
                         {
                             "topic_name": "Última Hora",
@@ -3901,48 +3901,48 @@
                         {
                             "topic_name": "Noticias destacadas",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Internacional",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Estados Unidos",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economía",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciencia y Tecnología",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Espectáculos",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Deportes",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salud",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Más noticias destacadas",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=es_us&hl=es&topic=h&output=rss"
                         }
                     ]
                 }

--- a/core/src/main/res/raw/news_data_fr.txt
+++ b/core/src/main/res/raw/news_data_fr.txt
@@ -15,43 +15,43 @@
                         {
                             "topic_name": "À la une",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "France",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=n&output=rss"
                         },
                         {
                             "topic_name": "International",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Économie",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Science/High-Tech",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Culture",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Santé",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=fr&hl=fr&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr&hl=fr&topic=m&output=rss"
                         }
                     ]
                 },
@@ -224,38 +224,38 @@
                         {
                             "topic_name": "À la une",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Canada",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Économie",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Science/High-Tech",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Culture",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Santé",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ca&hl=fr&topic=m&output=rss"
                         }
                     ]
                 },
@@ -376,48 +376,48 @@
                         {
                             "topic_name": "À la une",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&output=rss",
+                            "url": "https://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "International",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=w&output=rss"
+                            "url": "https://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Belgique",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=n&output=rss"
+                            "url": "https://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Économie",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=b&output=rss"
+                            "url": "https://news.google.com/news?pz=1&cf=all&ned=fr_be&hl=fr&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Science/High-Tech",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Culture",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Santé",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=m&output=rss"
                         },
                         {
                             "topic_name": "À la une (suite)",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_be&hl=fr&topic=h&output=rss"
                         }
                     ]
                 },
@@ -523,48 +523,48 @@
                         {
                             "topic_name": "À la une",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "International",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Suisse",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Économie",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Science/High-Tech",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Culture",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Santé",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=m&output=rss"
                         },
                         {
                             "topic_name": "À la une (suite)",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=fr_ch&hl=fr&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_hi.txt
+++ b/core/src/main/res/raw/news_data_hi.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "सुर्खियां",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "विश्व",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=w&output=rss"
                         },
                         {
                             "topic_name": "भारत",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=n&output=rss"
                         },
                         {
                             "topic_name": "व्यवसाय",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=b&output=rss"
                         },
                         {
                             "topic_name": "मनोरंजन",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=e&output=rss"
                         },
                         {
                             "topic_name": "खेलकूद",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=s&output=rss"
                         },
                         {
                             "topic_name": "और सुर्खियां",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hi_in&hl=hi&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_hu.txt
+++ b/core/src/main/res/raw/news_data_hu.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "Vezető hírek",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Nemzetközi",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Magyarország",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Üzleti élet",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Tudomány/technológia",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Kultúra/szórakozás",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hu_hu&hl=hu&topic=e&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_il.txt
+++ b/core/src/main/res/raw/news_data_il.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "בראש החדשות",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "ישראל",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=n&output=rss"
                         },
                         {
                             "topic_name": "עולם",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=w&output=rss"
                         },
                         {
                             "topic_name": "עסקים",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=b&output=rss"
                         },
                         {
                             "topic_name": "מדע/טכנולוגיה",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=t&output=rss"
                         },
                         {
                             "topic_name": "תרבות ובידור",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=e&output=rss"
                         },
                         {
                             "topic_name": "ספורט",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=s&output=rss"
                         },
                         {
                             "topic_name": "בריאות",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=m&output=rss"
                         },
                         {
                             "topic_name": "סיפורים מובילים נוספים",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=iw_il&hl=iw&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_it.txt
+++ b/core/src/main/res/raw/news_data_it.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Prima pagina",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Esteri",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Italia",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economia",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Scienza e tecnologia",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Intrattenimento",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Salute",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=m&output=rss"
                         },
                         {
                             "topic_name": "In evidenza",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=it&hl=it&topic=ir&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=it&hl=it&topic=ir&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_ko.txt
+++ b/core/src/main/res/raw/news_data_ko.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "주요뉴스",
                             "topic_id": "1",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss",
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "연예",
                             "topic_id": "2",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=e"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=e"
                         },
                         {
                             "topic_name": "스포츠",
                             "topic_id": "3",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=s"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=s"
                         },
                         {
                             "topic_name": "문화/생활",
                             "topic_id": "4",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=l"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=l"
                         },
                         {
                             "topic_name": "경제",
                             "topic_id": "5",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=b"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=b"
                         },
                         {
                             "topic_name": "사회",
                             "topic_id": "6",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=y"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=y"
                         },
                         {
                             "topic_name": "국제",
                             "topic_id": "7",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=w"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=w"
                         },
                         {
                             "topic_name": "과학기술",
                             "topic_id": "8",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=t"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=t"
                         },
                         {
                             "topic_name": "정치",
                             "topic_id": "9",
-                            "url": "http://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=p"
+                            "url": "https://news.google.co.kr/news?pz=1&cf=all&ned=kr&hl=ko&output=rss&topic=p"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_nb.txt
+++ b/core/src/main/res/raw/news_data_nb.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Hovedoppslag",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Utenriks",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Innenriks",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Næringsliv",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Vitenskap/teknologi",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Underholdning",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Helse",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Flere hovedoppslag",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=no_no&hl=no&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=no_no&hl=no&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_nl.txt
+++ b/core/src/main/res/raw/news_data_nl.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Voorpaginanieuws",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Buitenland",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Nederland",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economie",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Wetenschap/techniek",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Gezondheid",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Meer voorpaginanieuws",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_nl&hl=nl&topic=h&output=rss"
                         }
                     ]
                 },
@@ -284,43 +284,43 @@
                         {
                             "topic_name": "Voorpaginanieuws",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Buitenland",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=w&output=rss"
                         },
                         {
                             "topic_name": "België",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Economie",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Wetenschap/techniek",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entertainment",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Meer voorpaginanieuws",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=nl_be&hl=nl&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_pl.txt
+++ b/core/src/main/res/raw/news_data_pl.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "Najważniejsze artykuły",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Świat",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Polska",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Gospodarka",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Nauka i technika",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Rozrywka",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pl_pl&hl=pl&topic=e&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_pt.txt
+++ b/core/src/main/res/raw/news_data_pt.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Notícias principais",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Mundo",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Portugal",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Negócios",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciência",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entretenimento",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Desporto",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Saúde",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Mais notícias principais",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-PT_pt&hl=pt-PT&topic=h&output=rss"
                         }
                     ]
                 },
@@ -184,48 +184,48 @@
                         {
                             "topic_name": "Últimas notícias",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Mundo",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Brasil",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Negócios",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Ciência/Tecnologia",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Entretenimento",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Esportes",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Saúde",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Mais notícias principais",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=pt-BR_br&hl=pt-BR&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_ru.txt
+++ b/core/src/main/res/raw/news_data_ru.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Главные новости",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "В мире",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Россия",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Бизнес",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Наука и техника",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Культура",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Спорт",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Здоровье",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Другие новости",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ru&hl=ru&topic=h&output=rss"
                         }
                     ]
                 },
@@ -326,38 +326,38 @@
                         {
                             "topic_name": "Главные новости",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "В мире",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Украина",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Бизнес",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Наука и техника",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Культура",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Спорт",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=ru_ua&hl=ru&topic=s&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_sv.txt
+++ b/core/src/main/res/raw/news_data_sv.txt
@@ -15,48 +15,48 @@
                         {
                             "topic_name": "Huvudnyheter",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Världen",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Sverige",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Ekonomi",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Vetenskap & teknik",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Nöje",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Sport",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Hälsa",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=m&output=rss"
                         },
                         {
                             "topic_name": "Fler huvudnyheter",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=sv_se&hl=sv&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_tr.txt
+++ b/core/src/main/res/raw/news_data_tr.txt
@@ -15,43 +15,43 @@
                         {
                             "topic_name": "En Çok Okunan Haberler",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Dünya",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Türkiye",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Ekonomi",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Bilim/Teknoloji",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Magazin",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Spor",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Sağlık",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tr_tr&hl=tr&topic=m&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_uk.txt
+++ b/core/src/main/res/raw/news_data_uk.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "Головні новини",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Світ",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Україна",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Бізнес",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Наука та техніка",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=t&output=rss"
                         },
                         {
                             "topic_name": "Розваги / Культура",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Спорт",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=uk_ua&hl=uk&topic=s&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_vi.txt
+++ b/core/src/main/res/raw/news_data_vi.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "Tin bài hàng đầu",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "Thế giới",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=w&output=rss"
                         },
                         {
                             "topic_name": "Việt Nam",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=n&output=rss"
                         },
                         {
                             "topic_name": "Kinh doanh",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=b&output=rss"
                         },
                         {
                             "topic_name": "Giải trí",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=e&output=rss"
                         },
                         {
                             "topic_name": "Thể thao",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=s&output=rss"
                         },
                         {
                             "topic_name": "Tin bài hàng đầu khác",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=h&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=vi_vn&hl=vi&topic=h&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_zh_cn.txt
+++ b/core/src/main/res/raw/news_data_zh_cn.txt
@@ -15,38 +15,38 @@
                         {
                             "topic_name": "焦点新闻",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "国际/港台",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=w&output=rss"
                         },
                         {
                             "topic_name": "内地",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=n&output=rss"
                         },
                         {
                             "topic_name": "财经",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=b&output=rss"
                         },
                         {
                             "topic_name": "娱乐",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=e&output=rss"
                         },
                         {
                             "topic_name": "科技",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=t&output=rss"
                         },
                         {
                             "topic_name": "体育",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=cn&hl=zh-CN&topic=s&output=rss"
                         }
                     ]
                 },

--- a/core/src/main/res/raw/news_data_zh_tw.txt
+++ b/core/src/main/res/raw/news_data_zh_tw.txt
@@ -15,53 +15,53 @@
                         {
                             "topic_name": "焦點新聞",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "國際",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=w&output=rss"
                         },
                         {
                             "topic_name": "台灣",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=n&output=rss"
                         },
                         {
                             "topic_name": "財經",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=b&output=rss"
                         },
                         {
                             "topic_name": "科技",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=t&output=rss"
                         },
                         {
                             "topic_name": "體育",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=s&output=rss"
                         },
                         {
                             "topic_name": "娛樂",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=e&output=rss"
                         },
                         {
                             "topic_name": "兩岸",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=c&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=c&output=rss"
                         },
                         {
                             "topic_name": "社會",
                             "topic_id": "9",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=y&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=y&output=rss"
                         },
                         {
                             "topic_name": "健康",
                             "topic_id": "10",
-                            "url": "http://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=m&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=tw&hl=zh-TW&topic=m&output=rss"
                         }
                     ]
                 },
@@ -279,43 +279,43 @@
                         {
                             "topic_name": "焦點新聞",
                             "topic_id": "1",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&output=rss",
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&output=rss",
                             "isDefault": "true"
                         },
                         {
                             "topic_name": "國際",
                             "topic_id": "2",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=w&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=w&output=rss"
                         },
                         {
                             "topic_name": "香港",
                             "topic_id": "3",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=n&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=n&output=rss"
                         },
                         {
                             "topic_name": "兩岸",
                             "topic_id": "4",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=c&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=c&output=rss"
                         },
                         {
                             "topic_name": "財經",
                             "topic_id": "5",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=b&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=b&output=rss"
                         },
                         {
                             "topic_name": "體育",
                             "topic_id": "6",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=s&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=s&output=rss"
                         },
                         {
                             "topic_name": "娛樂",
                             "topic_id": "7",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=e&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=e&output=rss"
                         },
                         {
                             "topic_name": "科技",
                             "topic_id": "8",
-                            "url": "http://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=t&output=rss"
+                            "url": "https://news.google.com/news?cf=all&ned=hk&hl=zh-TW&topic=t&output=rss"
                         }
                     ]
                 }


### PR DESCRIPTION
구글 뉴스 전체가 안 된다는 이사님의 제보가 있어 급히 조사.

http:// -> https://로 바뀌면서 안되는 문제인 것을 찾아내고 모든 주소를 변경해서 해결. 
